### PR TITLE
Fix invalid type assertion

### DIFF
--- a/src/ros/node.go
+++ b/src/ros/node.go
@@ -380,8 +380,11 @@ func (node *defaultNode) HasParam(key string) (bool, error) {
 
 func (node *defaultNode) SearchParam(key string) (string, error) {
 	result, e := callRosApi(node.masterUri, "searchParam", node.qualifiedName, key)
+	if e != nil {
+		return "", e
+	}
 	foundKey := result.(string)
-	return foundKey, e
+	return foundKey, nil
 }
 
 func (node *defaultNode) DeleteParam(key string) error {


### PR DESCRIPTION
Hi akio-san,

I find panic on the SearchParam type assertion.

```go
package example_test

import (
	"testing"

	"ros"
)

func TestSearchParam(t *testing.T) {
	node := ros.NewNode("/example_node")

	_, err := node.SearchParam("not_found")
	if err == nil {
		t.Errorf("want err, got nil")
	}
}
```

got panic:

```
go test
--- FAIL: TestSearchParam (0.00s)
panic: interface conversion: interface {} is nil, not string [recovered]
	panic: interface conversion: interface {} is nil, not string
```
