### PR TITLE
Fix xmlrpc and rosrpc URI

### DIFF
--- a/ros/network.go
+++ b/ros/network.go
@@ -1,0 +1,35 @@
+package ros
+
+import (
+	"net"
+	"os"
+	"strings"
+)
+
+func determineHost() (string, bool) {
+	// If the user set ROS_HOSTNAME, use it as is
+	if rosHostname, ok := os.LookupEnv("ROS_HOSTNAME"); ok {
+		return rosHostname, (rosHostname == "localhost")
+	}
+
+	// If the user set ROS_IP, use it as is
+	if rosIp, ok := os.LookupEnv("ROS_IP"); ok {
+		return rosIp, (rosIp == "::1" || strings.HasPrefix(rosIp, "127."))
+	}
+
+	// Try using the hostname
+	if osHostname, err := os.Hostname(); err == nil && osHostname != "localhost" {
+		return osHostname, false
+	}
+
+	// Fall back on the interface IP
+	if addrs, err := net.InterfaceAddrs(); err == nil {
+		for _, addr := range addrs {
+			if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+				return ipnet.IP.String(), false
+			}
+		}
+	}
+	// Fall back to the loopback UP
+	return "127.0.0.1", true
+}

--- a/ros/network_test.go
+++ b/ros/network_test.go
@@ -1,0 +1,64 @@
+package ros
+
+import (
+	"os"
+	"testing"
+)
+
+func TestDetermineHost(t *testing.T) {
+	os.Unsetenv("ROS_HOSTNAME")
+	os.Unsetenv("ROS_IP")
+
+	var host string
+	var localOnly bool
+
+	// ROS_HOSTNAME: localhost, ROS_IP: nil
+	os.Setenv("ROS_HOSTNAME", "localhost")
+	host, localOnly = determineHost()
+	if host != "localhost" {
+		t.Error("ROS_HOSTNAME is not addressed")
+	}
+	if localOnly != true {
+		t.Errorf("localOnly flag is wrong for %s", host)
+	}
+
+	// ROS_HOSTNAME: hostname.in.env.var, ROS_IP: nil
+	os.Setenv("ROS_HOSTNAME", "hostname.in.env.var")
+	host, localOnly = determineHost()
+	if host != "hostname.in.env.var" {
+		t.Error("ROS_HOSTNAME is not addressed")
+	}
+	if localOnly != false {
+		t.Errorf("localOnly flag is wrong for %s", host)
+	}
+
+	// ROS_HOSTNAME: hostname.in.env.var, ROS_IP: 1.2.3.4
+	os.Setenv("ROS_IP", "1.2.3.4")
+	host, localOnly = determineHost()
+	if host != "hostname.in.env.var" {
+		t.Error("ROS_HOSTNAME is not addressed when ROS_IP is set")
+	}
+	if localOnly != false {
+		t.Errorf("localOnly flag is wrong for %s", host)
+	}
+
+	// ROS_HOSTNAME: nil, ROS_IP: 1.2.3.4
+	os.Unsetenv("ROS_HOSTNAME")
+	host, localOnly = determineHost()
+	if host != "1.2.3.4" {
+		t.Error("ROS_IP is not addressed")
+	}
+	if localOnly != false {
+		t.Errorf("localOnly flag is wrong for %s", host)
+	}
+
+	// ROS_HOSTNAME: nil, ROS_IP: 127.0.0.1
+	os.Setenv("ROS_IP", "127.0.0.1")
+	host, localOnly = determineHost()
+	if host != "127.0.0.1" {
+		t.Error("ROS_HOSTNAME is not addressed when ROS_IP is set")
+	}
+	if localOnly != true {
+		t.Errorf("localOnly flag is wrong for %s", host)
+	}
+}


### PR DESCRIPTION
for #14 

This PR implements hostname determination algorithm which works similar to the roscpp.
~~~(not yet well-tested)~~~

I have tested communication between rosgo publisher and `rostopic echo` in different host by using following docker-compose and Dockerfile.

```yaml
version: "3.5"
services:
  ros-master:
    image: ros:kinetic
    command: ["roscore"]
    hostname: ros-master
    networks:
      static_net:
        ipv4_address: 172.18.18.10
  talker:
    build: .
    environment:
      ROS_MASTER_URI: "http://ros-master:11311"
      #ROS_IP: 172.18.18.11
      #ROS_HOSTNAME: talker
    hostname: talker
    command: ["sh", "-c", "sleep 2; /test_talker"]
    networks:
      static_net:
        ipv4_address: 172.18.18.11
  listener:
    image: ros:kinetic
    command: ["bash", "-c", "sleep 2; rostopic echo /chatter"]
    environment:
      ROS_MASTER_URI: "http://ros-master:11311"
    hostname: listener
    networks:
      static_net:
        ipv4_address: 172.18.18.12

networks:
  static_net:
    ipam:
      config:
        - subnet: 172.18.18.0/24
```
```Dockerfile
FROM alpine:3.8

# assuming that test_talker is built by go build -tags netgo .
COPY test_talker /
CMD ["/test_talker"]
```

This works like:
```
talker_1      | hello 2018-09-26 06:13:03.934807455 +0000 UTC m=+2.038682377
talker_1      | 2018/09/26 06:13:03 [DEBUG] Receive msgChan
talker_1      | 2018/09/26 06:13:03 [DEBUG] defaultPublisher.start loop
talker_1      | 2018/09/26 06:13:03 [DEBUG] Receive msgChan
talker_1      | 2018/09/26 06:13:03 [DEBUG] writing
talker_1      | 2018/09/26 06:13:03 [DEBUG] 3c00000068656c6c6f20323031382d30392d32362030363a31333a30332e393334383037343535202b3030303020555443206d3d2b322e303338363832333737
talker_1      | 2018/09/26 06:13:03 [DEBUG] 64
talker_1      | 2018/09/26 06:13:03 [DEBUG] 3c00000068656c6c6f20323031382d30392d32362030363a31333a30332e393334383037343535202b3030303020555443206d3d2b322e303338363832333737
listener_1    | data: "hello 2018-09-26 06:13:03.934807455 +0000 UTC m=+2.038682377"
listener_1    | ---
```

I'll also test service server quickly.