### PR TITLE
Fix md5 sum of array field type

### DIFF
--- a/gengo/context.go
+++ b/gengo/context.go
@@ -241,7 +241,13 @@ func (ctx *MsgContext) ComputeMD5Text(spec *MsgSpec) (string, error) {
 	}
 	for _, f := range spec.Fields {
 		if f.Package == "" {
-			buf.WriteString(fmt.Sprintf("%s %s\n", f.Type, f.Name))
+			if f.IsArray && f.ArrayLen > -1 {
+				buf.WriteString(fmt.Sprintf("%s[%d] %s\n", f.Type, f.ArrayLen, f.Name))
+			} else if f.IsArray {
+				buf.WriteString(fmt.Sprintf("%s[] %s\n", f.Type, f.Name))
+			} else {
+				buf.WriteString(fmt.Sprintf("%s %s\n", f.Type, f.Name))
+			}
 		} else {
 			subspec, err := ctx.LoadMsg(f.Package + "/" + f.Type)
 			if err != nil {


### PR DESCRIPTION
This PR tries to fix md5 sum calculation. If the message has the field `float64[36] covariance`, the current implementation uses `float64 covariance` for its md5 text. This PR fixes it to `float64[36] covariance`.

I got `c23e848cf1b7533a8d7c259073a97e6f` for `geometry_msgs/PoseWithCovariance` message type with this change, which corresponds to `rosmsg md5` output of the type.

---
fixes #23 